### PR TITLE
feat: standardize navigation bar across pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,49 +4,25 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Shibaprasad Bhattacharya</title>
-    <style>
-        body { 
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
-            max-width: 800px; margin: 0 auto; padding: 20px; line-height: 1.6; 
-            background: #f8f9fa; color: #333;
-        }
-        .container {
-            background: white; padding: 40px; border-radius: 8px; 
-            box-shadow: 0 2px 10px rgba(0,0,0,0.08);
-        }
-        nav { 
-            background: #2c3e50; padding: 15px; margin-bottom: 30px; border-radius: 6px; 
-        }
-        nav a { 
-            margin-right: 25px; text-decoration: none; color: white; font-weight: 500; 
-            transition: color 0.2s;
-        }
-        nav a:hover { color: #3498db; }
-        h1 { color: #2c3e50; font-size: 2em; margin-bottom: 15px; }
-        a { color: #3498db; text-decoration: none; }
-        a:hover { color: #2980b9; text-decoration: underline; }
-        .intro { font-size: 1.1em; margin-bottom: 25px; color: #555; }
-        .contact { margin-top: 30px; padding-top: 20px; border-top: 1px solid #eee; }
-    </style>
+    <link rel='stylesheet' href='style.css'>
 </head>
 <body>
+    <nav>
+        <a href="index.html">Home</a>
+        <a href="https://datasignal.substack.com" target="_blank">Blog</a>
+        <a href="publications.html">Publications</a>
+        <a href="about.html">About</a>
+    </nav>
     <div class="container">
-        <nav>
-            <a href="index.html">Home</a>
-            <a href="https://datasignal.substack.com" target="_blank">Blog</a>
-            <a href="publications.html">Publications</a>
-            <a href="about.html">About</a>
-        </nav>
-
         <h1>Welcome!</h1>
         <p class="intro">I am Shibaprasad Bhattacharya, a Data Science Generalist | Analytics, AI, Product & Strategy</p>
-        
+
         <p>I share my work and insights through these newsletters:</p>
         <p>• <a href="https://datasignal.substack.com">Data Signal</a> - Technical content on data science and analytics</p>
         <p>• <a href="https://ordinaryanalysis.substack.com/">Ordinary Analysis</a> - Personal observations and thoughts</p>
-        
+
         <p>Currently working as Data Analyst II at Bristol Myers Squibb.</p>
-        
+
         <div class="contact">
             <p>Contact: <a href="mailto:shibaprasad.b@outlook.com">shibaprasad.b@outlook.com</a></p>
         </div>

--- a/index.html
+++ b/index.html
@@ -4,16 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Shibaprasad Bhattacharya</title>
-    <style>
-        body { font-family: Arial, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; line-height: 1.6; }
-        nav { background: #f4f4f4; padding: 15px; margin-bottom: 30px; border-radius: 5px; }
-        nav a { margin-right: 20px; text-decoration: none; color: #333; font-weight: bold; }
-        nav a:hover { color: #0066cc; }
-        h1 { color: #333; }
-        a { color: #0066cc; }
-        .publications { margin: 20px 0; }
-        .pub-item { margin-bottom: 15px; padding: 10px; background: #f9f9f9; border-radius: 3px; }
-    </style>
+    <link rel='stylesheet' href='style.css'>
 </head>
 <body>
     <nav>
@@ -22,15 +13,16 @@
         <a href="publications.html">Publications</a>
         <a href="about.html">About</a>
     </nav>
+    <div class="container">
+        <h1>Welcome!</h1>
+        <p>I am Shibaprasad Bhattacharya, a Data nerd. On this site, I share some of my works related to Data, Stats, and OR.</p>
 
-    <h1>Welcome!</h1>
-    <p>I am Shibaprasad Bhattacharya, a Data nerd. On this site, I share some of my works related to Data, Stats, and OR.</p>
-    
-    <p>I write a semi-regular data blog-newsletter: <a href="https://datasignal.substack.com">Data Signal</a></p>
-    <p>I also have a personal newsletter: <a href="https://ordinaryanalysis.substack.com/">Ordinary Analysis</a></p>
-    
-    <p>Currently, I am working as a Data Analyst II at Bristol Myers Squibb. Before that, I had worked at Air India and Delhivery.</p>
-    
-    <p>I am available at shibaprasad.b@outlook.com</p>
+        <p>I write a semi-regular data blog-newsletter: <a href="https://datasignal.substack.com">Data Signal</a></p>
+        <p>I also have a personal newsletter: <a href="https://ordinaryanalysis.substack.com/">Ordinary Analysis</a></p>
+
+        <p>Currently, I am working as a Data Analyst II at Bristol Myers Squibb. Before that, I had worked at Air India and Delhivery.</p>
+
+        <p>I am available at shibaprasad.b@outlook.com</p>
+    </div>
 </body>
 </html>

--- a/publications.html
+++ b/publications.html
@@ -4,16 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Publications - Shibaprasad Bhattacharya</title>
-    <style>
-        body { font-family: Arial, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; line-height: 1.6; }
-        nav { background: #f4f4f4; padding: 15px; margin-bottom: 30px; border-radius: 5px; }
-        nav a { margin-right: 20px; text-decoration: none; color: #333; font-weight: bold; }
-        nav a:hover { color: #0066cc; }
-        h1, h2 { color: #333; }
-        .year-section { margin: 30px 0; }
-        .pub-item { margin: 15px 0; padding-left: 20px; }
-        .pub-item:before { content: "• "; color: #0066cc; font-weight: bold; }
-    </style>
+    <link rel='stylesheet' href='style.css'>
 </head>
 <body>
     <nav>
@@ -22,25 +13,26 @@
         <a href="publications.html">Publications</a>
         <a href="about.html">About</a>
     </nav>
+    <div class="container">
+        <h1>Publications</h1>
 
-    <h1>Publications</h1>
-    
-    <div class="year-section">
-        <h2>2022</h2>
-        <div class="pub-item">PREDICTION OF RESPONSES IN A CNC MILLING OPERATION USING RANDOM FOREST REGRESSOR</div>
-    </div>
+        <div class="year-section">
+            <h2>2022</h2>
+            <div class="pub-item">PREDICTION OF RESPONSES IN A CNC MILLING OPERATION USING RANDOM FOREST REGRESSOR</div>
+        </div>
 
-    <div class="year-section">
-        <h2>2021</h2>
-        <div class="pub-item">Prediction of Responses in a Sustainable Dry Turning Operation: A Comparative Analysis</div>
-        <div class="pub-item">Application of XGBoost Algorithm as a Predictive Tool in a CNC Turning Process</div>
-        <div class="pub-item">A Comparative Analysis on Prediction Performance of Regression Models during Machining of Composite Materials</div>
-    </div>
+        <div class="year-section">
+            <h2>2021</h2>
+            <div class="pub-item">Prediction of Responses in a Sustainable Dry Turning Operation: A Comparative Analysis</div>
+            <div class="pub-item">Application of XGBoost Algorithm as a Predictive Tool in a CNC Turning Process</div>
+            <div class="pub-item">A Comparative Analysis on Prediction Performance of Regression Models during Machining of Composite Materials</div>
+        </div>
 
-    <div class="year-section">
-        <h2>2017</h2>
-        <div class="pub-item">A study on Bingham plastic characteristics of blood flow through multiple overlapped stenosed arteries</div>
-        <div class="pub-item">Study on the effect of non-Newtonian nature of blood flowing through an elastic artery with slip condition</div>
+        <div class="year-section">
+            <h2>2017</h2>
+            <div class="pub-item">A study on Bingham plastic characteristics of blood flow through multiple overlapped stenosed arteries</div>
+            <div class="pub-item">Study on the effect of non-Newtonian nature of blood flowing through an elastic artery with slip condition</div>
+        </div>
     </div>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,76 @@
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+  line-height: 1.6;
+  background: #f8f9fa;
+  color: #333;
+}
+
+nav {
+  background: #2c3e50;
+  padding: 15px;
+  margin-bottom: 30px;
+  border-radius: 6px;
+}
+
+nav a {
+  margin-right: 20px;
+  text-decoration: none;
+  color: white;
+  font-weight: 500;
+  transition: color 0.2s;
+}
+
+nav a:hover {
+  color: #3498db;
+}
+
+h1, h2 {
+  color: #2c3e50;
+}
+
+a {
+  color: #3498db;
+  text-decoration: none;
+}
+
+a:hover {
+  color: #2980b9;
+  text-decoration: underline;
+}
+
+.container {
+  background: white;
+  padding: 40px;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+}
+
+.intro {
+  font-size: 1.1em;
+  margin-bottom: 25px;
+  color: #555;
+}
+
+.contact {
+  margin-top: 30px;
+  padding-top: 20px;
+  border-top: 1px solid #eee;
+}
+
+.year-section {
+  margin: 30px 0;
+}
+
+.pub-item {
+  margin: 15px 0;
+  padding-left: 20px;
+}
+
+.pub-item::before {
+  content: "• ";
+  color: #0066cc;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- move navigation out of container on About page
- wrap Home and Publications content in a shared container
- rely on one `style.css` for consistent layout and blue nav bar

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b41f07c8ac8324a218754383914ef3