### PR TITLE
Add GoatCounter analytics to pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,6 +6,9 @@
     <title>About - Shibaprasad Bhattacharya</title>
     <link rel='stylesheet' href='style.css'>
     <link rel="icon" type="image/png" href="images/headshot.jpg">
+    <!-- GoatCounter Analytics -->
+    <script data-goatcounter="https://shibaprasadb.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
 </head>
 <body>
     <nav>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,9 @@
     <title>Shibaprasad Bhattacharya</title>
     <link rel='stylesheet' href='style.css'>
     <link rel="icon" type="image/png" href="images/headshot.jpg">
+    <!-- GoatCounter Analytics -->
+    <script data-goatcounter="https://shibaprasadb.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
 </head>
 <body>
     <nav>

--- a/publications.html
+++ b/publications.html
@@ -6,6 +6,9 @@
     <title>Publications - Shibaprasad Bhattacharya</title>
     <link rel='stylesheet' href='style.css'>
     <link rel="icon" type="image/png" href="images/headshot.jpg">
+    <!-- GoatCounter Analytics -->
+    <script data-goatcounter="https://shibaprasadb.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
 </head>
 <body>
     <nav>


### PR DESCRIPTION
## Summary
- add GoatCounter analytics script to the head of all site pages for visitor tracking

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b47c3757148324a547aac7107ba4e8