### PR TITLE
Add social icons to navigation bar

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,6 +16,8 @@
         <a href="https://datasignal.substack.com" target="_blank">Blog</a>
         <a href="publications.html">Publications</a>
         <a href="about.html">About</a>
+        <a href="https://www.linkedin.com/in/shibaprasad-bhattacharya/" target="_blank"><img src="images/linkedin_logo.png" alt="LinkedIn" class="nav-icon"></a>
+        <a href="https://github.com/shibaprasadb" target="_blank"><img src="images/github_logo.png" alt="GitHub" class="nav-icon"></a>
     </nav>
     <div class="container about">
         <h1>About Me</h1>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,8 @@
         <a href="https://datasignal.substack.com" target="_blank">Blog</a>
         <a href="publications.html">Publications</a>
         <a href="about.html">About</a>
+        <a href="https://www.linkedin.com/in/shibaprasad-bhattacharya/" target="_blank"><img src="images/linkedin_logo.png" alt="LinkedIn" class="nav-icon"></a>
+        <a href="https://github.com/shibaprasadb" target="_blank"><img src="images/github_logo.png" alt="GitHub" class="nav-icon"></a>
     </nav>
     <div class="container">
         <h1>Shibaprasad Bhattacharya</h1>

--- a/publications.html
+++ b/publications.html
@@ -16,6 +16,8 @@
         <a href="https://datasignal.substack.com" target="_blank">Blog</a>
         <a href="publications.html">Publications</a>
         <a href="about.html">About</a>
+        <a href="https://www.linkedin.com/in/shibaprasad-bhattacharya/" target="_blank"><img src="images/linkedin_logo.png" alt="LinkedIn" class="nav-icon"></a>
+        <a href="https://github.com/shibaprasadb" target="_blank"><img src="images/github_logo.png" alt="GitHub" class="nav-icon"></a>
     </nav>
     <div class="container">
         <h1>Publications</h1>

--- a/style.css
+++ b/style.css
@@ -27,6 +27,12 @@ nav a:hover {
   color: #3498db;
 }
 
+nav .nav-icon {
+  width: 24px;
+  height: 24px;
+  vertical-align: middle;
+}
+
 h1, h2 {
   color: #2c3e50;
 }


### PR DESCRIPTION
## Summary
- Add LinkedIn and GitHub icons with links in the navigation bar across all pages
- Style navigation icons for consistent sizing and alignment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b481cff21c8324a14f41ac32e78c91