### PR TITLE
feat: add dedicated blog page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The site includes:
 - **Home**: Quick intro and links  
 - **About**: My professional journey and interests  
 - **Publications**: Selected research work  
-- **Blog**: Redirects to my Substack newsletters  
+- **Blog**: Link to my Data Signal Substack newsletter
 
 ---
 Contact: [shibaprasad.b@outlook.com](mailto:shibaprasad.b@outlook.com)

--- a/about.html
+++ b/about.html
@@ -13,7 +13,7 @@
 <body>
     <nav>
         <a href="index.html">Home</a>
-        <a href="https://datasignal.substack.com" target="_blank">Blog</a>
+        <a href="blog.html">Blog</a>
         <a href="publications.html">Publications</a>
         <a href="about.html">About</a>
         <a href="https://www.linkedin.com/in/shibaprasad-bhattacharya/" target="_blank"><img src="images/linkedin_logo.png" alt="LinkedIn" class="nav-icon"></a>

--- a/blog.html
+++ b/blog.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Shibaprasad Bhattacharya</title>
+    <title>Blog - Shibaprasad Bhattacharya</title>
     <link rel='stylesheet' href='style.css'>
     <link rel="icon" type="image/png" href="images/headshot.jpg">
     <!-- GoatCounter Analytics -->
@@ -20,16 +20,11 @@
         <a href="https://github.com/shibaprasadb" target="_blank"><img src="images/github_logo.png" alt="GitHub" class="nav-icon"></a>
     </nav>
     <div class="container">
-        <h1>Shibaprasad Bhattacharya</h1>
-        <h2>Data Science | Product Thinking</h2>
-        <p><em>Asking the right questions to unlock insights.</em></p>
-
-        <p>I am a Data Science Generalist who solves problems at the intersection of <strong>AI, Analytics, and Strategy</strong>. 
-        I enjoy tackling ambiguous, challenging problems with product-driven thinking.</p>
-
-        <p>Currently working as <strong>Data Analyst II at Bristol Myers Squibb</strong>. Previously, I worked at <strong>Air India</strong> and <strong>Delhivery</strong>.</p>
-
-        <p><strong>Contact:</strong> <a href="mailto:shibaprasad.b@outlook.com">shibaprasad.b@outlook.com</a></p>
+        <h1>Blog</h1>
+        <p>Read my latest newsletter:</p>
+        <ul>
+            <li><a href="https://datasignal.substack.com" target="_blank">Data Signal</a> – Technical content on data science and analytics</li>
+        </ul>
     </div>
 </body>
 </html>

--- a/publications.html
+++ b/publications.html
@@ -13,7 +13,7 @@
 <body>
     <nav>
         <a href="index.html">Home</a>
-        <a href="https://datasignal.substack.com" target="_blank">Blog</a>
+        <a href="blog.html">Blog</a>
         <a href="publications.html">Publications</a>
         <a href="about.html">About</a>
         <a href="https://www.linkedin.com/in/shibaprasad-bhattacharya/" target="_blank"><img src="images/linkedin_logo.png" alt="LinkedIn" class="nav-icon"></a>


### PR DESCRIPTION
## Summary
- create `blog.html` to host newsletter links and retain site analytics
- remove newsletter section from home page and link navigation to new blog page across site
- update README to describe the new blog page
- temporarily show only the Data Signal newsletter on the blog page

## Testing
- `npx html-validate index.html about.html publications.html blog.html` *(fails: 403 Forbidden from npm registry)*
- `tidy -q -e index.html about.html publications.html blog.html` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden on repository access)*

------
https://chatgpt.com/codex/tasks/task_e_68b6417f1e348324a5acf98b7b36cf85