### PR TITLE
Load navigation from shared partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,14 @@
 This repository hosts my personal website: [shibaprasadb.github.io](https://shibaprasadb.github.io).
 
 The site includes:
-- **Home**: Quick intro and links  
-- **About**: My professional journey and interests  
-- **Publications**: Selected research work  
+- **Home**: Quick intro and links
+- **About**: My professional journey and interests
+- **Publications**: Selected research work
 - **Blog**: Link to my Data Signal Substack newsletter
+
+## Navigation
+
+The navigation bar markup lives in `partials/nav.html` and is loaded into each page with a small client-side script. Update `partials/nav.html` to change navigation links across the site.
 
 ---
 Contact: [shibaprasad.b@outlook.com](mailto:shibaprasad.b@outlook.com)

--- a/about.html
+++ b/about.html
@@ -11,40 +11,40 @@
             async src="//gc.zgo.at/count.js"></script>
 </head>
 <body>
-    <nav>
-        <a href="index.html">Home</a>
-        <a href="blog.html">Blog</a>
-        <a href="publications.html">Publications</a>
-        <a href="about.html">About</a>
-        <a href="https://www.linkedin.com/in/shibaprasad-bhattacharya/" target="_blank"><img src="images/linkedin_logo.png" alt="LinkedIn" class="nav-icon"></a>
-        <a href="https://github.com/shibaprasadb" target="_blank"><img src="images/github_logo.png" alt="GitHub" class="nav-icon"></a>
-    </nav>
+    <div id="nav"></div>
     <div class="container about">
         <h1>About Me</h1>
 
         <!-- Headshot -->
         <img src="images/headshot.jpg" alt="Shibaprasad Bhattacharya" class="headshot" loading="lazy">
 
-        <p>I believe analytics creates real value when it's tied to strategy and product decisions. 
+        <p>I believe analytics creates real value when it's tied to strategy and product decisions.
         That's where I like to work - where data actually drives what happens next.</p>
 
-        <p>I do my best work on messy, ambiguous business problems. 
-        The kind where you're not sure what question to ask, let alone how to answer it. 
+        <p>I do my best work on messy, ambiguous business problems.
+        The kind where you're not sure what question to ask, let alone how to answer it.
         I've learned that framing the problem right is usually harder (and more important) than building the perfect model.</p>
 
         <h3>Professional Journey</h3>
-        <p>My career has taken me through different industries: I started at Delhivery in Analytics & BI, 
-        then moved to Air India's Operations Tech team, and now I'm with the Drug Development team at Bristol Myers Squibb, 
+        <p>My career has taken me through different industries: I started at Delhivery in Analytics & BI,
+        then moved to Air India's Operations Tech team, and now I'm with the Drug Development team at Bristol Myers Squibb,
         working on projects that hopefully help patients.</p>
 
         <h3>Outside of Work</h3>
-        <p>When I'm not working with data, you can find me strength training, 
-        exploring the art of brewing coffee, and occasionally writing on my newsletter, 
+        <p>When I'm not working with data, you can find me strength training,
+        exploring the art of brewing coffee, and occasionally writing on my newsletter,
         where I share both technical explorations and personal reflections.</p>
 
         <div class="contact">
             <p><strong>Contact:</strong> <a href="mailto:shibaprasad.b@outlook.com">shibaprasad.b@outlook.com</a></p>
         </div>
     </div>
+    <script>
+        fetch('partials/nav.html')
+            .then(response => response.text())
+            .then(html => {
+                document.getElementById('nav').innerHTML = html;
+            });
+    </script>
 </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -11,14 +11,7 @@
             async src="//gc.zgo.at/count.js"></script>
 </head>
 <body>
-    <nav>
-        <a href="index.html">Home</a>
-        <a href="blog.html">Blog</a>
-        <a href="publications.html">Publications</a>
-        <a href="about.html">About</a>
-        <a href="https://www.linkedin.com/in/shibaprasad-bhattacharya/" target="_blank"><img src="images/linkedin_logo.png" alt="LinkedIn" class="nav-icon"></a>
-        <a href="https://github.com/shibaprasadb" target="_blank"><img src="images/github_logo.png" alt="GitHub" class="nav-icon"></a>
-    </nav>
+    <div id="nav"></div>
     <div class="container">
         <h1>Blog</h1>
         <p>Read my latest newsletter:</p>
@@ -26,5 +19,12 @@
             <li><a href="https://datasignal.substack.com" target="_blank">Data Signal</a> – Technical content on data science and analytics</li>
         </ul>
     </div>
+    <script>
+        fetch('partials/nav.html')
+            .then(response => response.text())
+            .then(html => {
+                document.getElementById('nav').innerHTML = html;
+            });
+    </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -11,25 +11,25 @@
             async src="//gc.zgo.at/count.js"></script>
 </head>
 <body>
-    <nav>
-        <a href="index.html">Home</a>
-        <a href="blog.html">Blog</a>
-        <a href="publications.html">Publications</a>
-        <a href="about.html">About</a>
-        <a href="https://www.linkedin.com/in/shibaprasad-bhattacharya/" target="_blank"><img src="images/linkedin_logo.png" alt="LinkedIn" class="nav-icon"></a>
-        <a href="https://github.com/shibaprasadb" target="_blank"><img src="images/github_logo.png" alt="GitHub" class="nav-icon"></a>
-    </nav>
+    <div id="nav"></div>
     <div class="container">
         <h1>Shibaprasad Bhattacharya</h1>
         <h2>Data Science | Product Thinking</h2>
         <p><em>Asking the right questions to unlock insights.</em></p>
 
-        <p>I am a Data Science Generalist who solves problems at the intersection of <strong>AI, Analytics, and Strategy</strong>. 
+        <p>I am a Data Science Generalist who solves problems at the intersection of <strong>AI, Analytics, and Strategy</strong>.
         I enjoy tackling ambiguous, challenging problems with product-driven thinking.</p>
 
         <p>Currently working as <strong>Data Analyst II at Bristol Myers Squibb</strong>. Previously, I worked at <strong>Air India</strong> and <strong>Delhivery</strong>.</p>
 
         <p><strong>Contact:</strong> <a href="mailto:shibaprasad.b@outlook.com">shibaprasad.b@outlook.com</a></p>
     </div>
+    <script>
+        fetch('partials/nav.html')
+            .then(response => response.text())
+            .then(html => {
+                document.getElementById('nav').innerHTML = html;
+            });
+    </script>
 </body>
 </html>

--- a/partials/nav.html
+++ b/partials/nav.html
@@ -1,0 +1,8 @@
+<nav>
+    <a href="index.html">Home</a>
+    <a href="blog.html">Blog</a>
+    <a href="publications.html">Publications</a>
+    <a href="about.html">About</a>
+    <a href="https://www.linkedin.com/in/shibaprasad-bhattacharya/" target="_blank"><img src="images/linkedin_logo.png" alt="LinkedIn" class="nav-icon"></a>
+    <a href="https://github.com/shibaprasadb" target="_blank"><img src="images/github_logo.png" alt="GitHub" class="nav-icon"></a>
+</nav>

--- a/publications.html
+++ b/publications.html
@@ -11,14 +11,7 @@
             async src="//gc.zgo.at/count.js"></script>
 </head>
 <body>
-    <nav>
-        <a href="index.html">Home</a>
-        <a href="blog.html">Blog</a>
-        <a href="publications.html">Publications</a>
-        <a href="about.html">About</a>
-        <a href="https://www.linkedin.com/in/shibaprasad-bhattacharya/" target="_blank"><img src="images/linkedin_logo.png" alt="LinkedIn" class="nav-icon"></a>
-        <a href="https://github.com/shibaprasadb" target="_blank"><img src="images/github_logo.png" alt="GitHub" class="nav-icon"></a>
-    </nav>
+    <div id="nav"></div>
     <div class="container">
         <h1>Publications</h1>
         <ul class="pub-list">
@@ -30,5 +23,12 @@
             <li>Study on the effect of non-Newtonian nature of blood flowing through an elastic artery with slip condition (2017)</li>
         </ul>
     </div>
+    <script>
+        fetch('partials/nav.html')
+            .then(response => response.text())
+            .then(html => {
+                document.getElementById('nav').innerHTML = html;
+            });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extract shared navigation markup into `partials/nav.html`
- load nav into pages with a small client-side script
- document nav workflow in `README`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b678470f248324b492a19c102c832e