### PR TITLE
Display posts on blog page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
 title: Shibaprasad Bhattacharya
 baseurl: ""
 url: "https://shibaprasadb.github.io"
+future: true

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,8 @@
+---
+layout: default
+---
+<div class="container">
+  <h1>{{ page.title }}</h1>
+  <p class="post-date">{{ page.date | date: "%B %-d, %Y" }}</p>
+  {{ content }}
+</div>

--- a/blog.html
+++ b/blog.html
@@ -8,4 +8,13 @@ title: Blog
     <ul>
         <li><a href="https://datasignal.substack.com" target="_blank">Data Signal</a> – Technical content on data science and analytics</li>
     </ul>
+    <h2>Posts</h2>
+    <ul class="post-list">
+        {% for post in site.posts %}
+        <li>
+            <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+            <span class="post-date">{{ post.date | date: "%B %-d, %Y" }}</span>
+        </li>
+        {% endfor %}
+    </ul>
 </div>

--- a/style.css
+++ b/style.css
@@ -118,3 +118,18 @@ a:hover {
   margin-bottom: 12px;
   line-height: 1.5;
 }
+
+.post-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.post-list li {
+  margin-bottom: 10px;
+}
+
+.post-date {
+  color: #777;
+  font-size: 0.9em;
+  margin-left: 10px;
+}


### PR DESCRIPTION
## Summary
- Add post layout and styles for blog entries
- List site posts on the blog page
- Enable future-dated posts for preview

## Testing
- `jekyll build >/tmp/jekyll.log && tail -n 20 /tmp/jekyll.log` *(command not found)*
- `gem install jekyll >/tmp/jekyll_install.log && tail -n 20 /tmp/jekyll_install.log` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b64d7f6c83249ae792d08e433b6c