### PR TITLE
Use root-relative URLs in navigation

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,8 +1,8 @@
 <nav>
-    <a href="index.html">Home</a>
-    <a href="blog.html">Blog</a>
-    <a href="publications.html">Publications</a>
-    <a href="about.html">About</a>
-    <a href="https://www.linkedin.com/in/shibaprasad-bhattacharya/" target="_blank"><img src="images/linkedin_logo.png" alt="LinkedIn" class="nav-icon"></a>
-    <a href="https://github.com/shibaprasadb" target="_blank"><img src="images/github_logo.png" alt="GitHub" class="nav-icon"></a>
+    <a href="{{ '/index.html' | relative_url }}">Home</a>
+    <a href="{{ '/blog.html' | relative_url }}">Blog</a>
+    <a href="{{ '/publications.html' | relative_url }}">Publications</a>
+    <a href="{{ '/about.html' | relative_url }}">About</a>
+    <a href="https://www.linkedin.com/in/shibaprasad-bhattacharya/" target="_blank"><img src="{{ '/images/linkedin_logo.png' | relative_url }}" alt="LinkedIn" class="nav-icon"></a>
+    <a href="https://github.com/shibaprasadb" target="_blank"><img src="{{ '/images/github_logo.png' | relative_url }}" alt="GitHub" class="nav-icon"></a>
 </nav>


### PR DESCRIPTION
## Summary
- ensure nav links and icons use Jekyll `relative_url` helper for proper root-relative paths

## Testing
- `bundle exec jekyll serve` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `gem install jekyll -v 4.3.3` *(fails: 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68b6d0c548f483249b90bc508de3e086