### PR TITLE
Add Substack subscribe page and embed widget

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -3,6 +3,7 @@
     <a href="{{ '/blog.html' | relative_url }}">Blog</a>
     <a href="{{ '/publications.html' | relative_url }}">Publications</a>
     <a href="{{ '/about.html' | relative_url }}">About</a>
+    <a href="{{ '/subscribe.html' | relative_url }}">Subscribe</a>
     <a href="https://www.linkedin.com/in/shibaprasad-bhattacharya/" target="_blank"><img src="{{ '/images/linkedin_logo.png' | relative_url }}" alt="LinkedIn" class="nav-icon"></a>
     <a href="https://github.com/shibaprasadb" target="_blank"><img src="{{ '/images/github_logo.png' | relative_url }}" alt="GitHub" class="nav-icon"></a>
 </nav>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,4 +5,10 @@ layout: default
   <h1>{{ page.title }}</h1>
   <p class="post-date">{{ page.date | date: "%B %-d, %Y" }}</p>
   {{ content }}
+  <hr />
+  <h3>Subscribe to Data Signal</h3>
+  <iframe src="https://datasignal.substack.com/embed"
+          width="100%" height="140"
+          style="border:1px solid #EEE; border-radius:8px; background:white;"
+          frameborder="0" scrolling="no"></iframe>
 </div>

--- a/subscribe.html
+++ b/subscribe.html
@@ -1,0 +1,28 @@
+---
+title: Subscribe
+layout: null
+---
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Subscribe — {{ site.title }}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="/style.css" />
+  <link rel="icon" type="image/png" href="/images/headshot.jpg" />
+</head>
+<body>
+  {% include nav.html %}
+  <div class="container">
+    <h1>Subscribe</h1>
+    <p>Get new posts from <strong>Data Signal</strong> in your inbox.</p>
+    <iframe src="https://datasignal.substack.com/embed"
+            width="100%" height="260"
+            style="border:1px solid #EEE; border-radius:8px; background:white;"
+            frameborder="0" scrolling="no"></iframe>
+    <p style="margin-top:12px">
+      Prefer the full page? <a href="https://datasignal.substack.com/subscribe" target="_blank" rel="noreferrer">Open Substack →</a>
+    </p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated `subscribe.html` with Substack embed
- link Subscribe in site nav
- include inline subscribe iframe at end of blog posts

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6da1366888324b19b7d55cd74e926