### PR TITLE
Enable Giscus comments on posts

### DIFF
--- a/_includes/giscus.html
+++ b/_includes/giscus.html
@@ -1,0 +1,16 @@
+<script src="https://giscus.app/client.js"
+        data-repo="shibaprasadb/shibaprasadb.github.io"
+        data-repo-id="R_kgDOPnNBUA"
+        data-category="Comments"
+        data-category-id="DIC_kwDOPnNBUM4Cu6ZD"
+        data-mapping="pathname"
+        data-strict="0"
+        data-reactions-enabled="1"
+        data-emit-metadata="0"
+        data-input-position="top"
+        data-theme="preferred_color_scheme"
+        data-lang="en"
+        crossorigin="anonymous"
+        async>
+</script>
+

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -11,4 +11,5 @@ layout: default
           width="100%" height="140"
           style="border:1px solid #EEE; border-radius:8px; background:white;"
           frameborder="0" scrolling="no"></iframe>
+  {% include giscus.html %}
 </div>


### PR DESCRIPTION
## Summary
- add reusable Giscus snippet include
- render Giscus comments below posts

## Testing
- `gem install jekyll bundler` *(fails: 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f37b283483248ffc8df7c24a202d