### PR TITLE
Fix blog post order

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -10,8 +10,7 @@ title: Blog
     </ul>
     <h2>Posts</h2>
     <ul class="post-list">
-        {% assign posts = site.posts %}
-        {% for post in posts %}
+        {% for post in site.posts | sort: 'date' | reverse %}
         <li>
             <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
             <span class="post-date">{{ post.date | date: "%B %-d, %Y" }}</span>


### PR DESCRIPTION
## Summary
- sort posts by date during iteration so newest blog entries appear first

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 Forbidden)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*
- `apt-get install -y jekyll` *(fails: Unable to locate package jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e0c4b4c08324a358fbaf2b6cde2a