### PR TITLE
Add Umami analytics script

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,8 @@
     <!-- GoatCounter Analytics -->
     <script data-goatcounter="https://shibaprasadb.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>
+    <!-- Umami Analytics -->
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="2e67cd5c-f499-4fba-a139-481c5adb30c4"></script>
 </head>
 <body>
     {% include nav.html %}


### PR DESCRIPTION
## Summary
- Add Umami analytics script to default layout
- Retain existing GoatCounter tracking

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba83379ccc832488b5a1baf151906e