### PR TITLE
Add tag pages and generator

### DIFF
--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -1,0 +1,14 @@
+---
+layout: default
+---
+<div class="container">
+  <h2>Posts tagged "{{ page.tag }}"</h2>
+  <ul class="post-list">
+    {% for post in site.tags[page.tag] %}
+      <li class="post-item">
+        <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
+        <span class="post-date">{{ post.date | date: "%B %-d, %Y" }}</span>
+      </li>
+    {% endfor %}
+  </ul>
+</div>

--- a/_plugins/tag_generator.rb
+++ b/_plugins/tag_generator.rb
@@ -1,0 +1,25 @@
+module Jekyll
+  class TagPage < Page
+    def initialize(site, base, dir, tag)
+      @site = site
+      @base = base
+      @dir = dir
+      @name = 'index.html'
+
+      self.process(@name)
+      self.read_yaml(File.join(base, '_layouts'), 'tag.html')
+      self.data['tag'] = tag
+      self.data['title'] = "Posts tagged #{tag}"
+    end
+  end
+
+  class TagGenerator < Generator
+    safe true
+
+    def generate(site)
+      site.tags.each_key do |tag|
+        site.pages << TagPage.new(site, site.source, File.join('tags', tag), tag)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add layout for tag pages that lists posts matching a tag
- add plugin to generate per-tag index pages

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bb034ae9408324a50fe7aa3a9d20c2