### PR TITLE
Display tags on posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,6 +4,13 @@ layout: default
 <div class="container">
   <h1>{{ page.title }}</h1>
   <p class="post-date">{{ page.date | date: "%B %-d, %Y" }}</p>
+  {% if page.tags %}
+  <p class="post-tags">
+    {% for tag in page.tags %}
+      <a class="tag" href="/tags/{{ tag | slugify }}/">{{ tag }}</a>
+    {% endfor %}
+  </p>
+  {% endif %}
   {{ content }}
   <hr />
   <h3>Subscribe to Data Signal</h3>


### PR DESCRIPTION
## Summary
- show tags below the post date in the post layout

## Testing
- `jekyll build` (fails: command not found)
- `gem install jekyll` (fails: 403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_68bbf4457f48832493709a3a06ee3dc8