### PR TITLE
Add blog container with tag sidebar

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -2,7 +2,8 @@
 layout: default
 title: Blog
 ---
-<div class="container">
+<div class="blog-container">
+  <div class="container">
     <h2>Posts</h2>
     <ul class="post-list">
       {% for post in site.posts %}
@@ -12,4 +13,14 @@ title: Blog
         </li>
       {% endfor %}
     </ul>
+  </div>
+  <aside class="tag-sidebar">
+    <h2>Tags</h2>
+    <ul class="tag-list">
+      {% assign sorted_tags = site.tags | sort_natural %}
+      {% for tag in sorted_tags %}
+        <li><a href="/tags/{{ tag[0] | slugify }}/">{{ tag[0] }}</a></li>
+      {% endfor %}
+    </ul>
+  </aside>
 </div>


### PR DESCRIPTION
## Summary
- wrap blog page content in `blog-container`
- add tag sidebar listing all tags alphabetically

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bbf8fd7b708324a07b4a76ea238045