### PR TITLE
Fix tag sidebar to use tag names

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -17,9 +17,9 @@ title: Blog
   <aside class="tag-sidebar">
     <h2>Tags</h2>
     <ul class="tag-list">
-      {% assign sorted_tags = site.tags | sort_natural %}
+      {% assign sorted_tags = site.tags | keys | sort_natural %}
       {% for tag in sorted_tags %}
-        <li><a href="/tags/{{ tag[0] | slugify }}/">{{ tag[0] }}</a></li>
+        <li><a href="/tags/{{ tag | slugify }}/">{{ tag }}</a></li>
       {% endfor %}
     </ul>
   </aside>


### PR DESCRIPTION
## Summary
- update blog tag sidebar to iterate through tag names

## Testing
- `jekyll build` *(fails: command not found)*
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `gem install jekyll` *(fails: 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68bc1f56bb84832481ff6c3d0628ecdb