### PR TITLE
Deepen navigation bar color and keep it visible across pages

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -6,7 +6,6 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div class="blue-bar"></div>
   <nav>
     <a href="index.html">Home</a> |
     <a href="about.html">About</a> |

--- a/docs/blog.html
+++ b/docs/blog.html
@@ -6,7 +6,6 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div class="blue-bar"></div>
   <nav>
     <a href="index.html">Home</a> |
     <a href="about.html">About</a> |

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,6 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div class="blue-bar"></div>
   <nav>
     <a href="index.html">Home</a> |
     <a href="about.html">About</a> |

--- a/docs/publications.html
+++ b/docs/publications.html
@@ -6,7 +6,6 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div class="blue-bar"></div>
   <nav>
     <a href="index.html">Home</a> |
     <a href="about.html">About</a> |

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,16 +1,18 @@
-.blue-bar {
-  background-color: #007bff;
-  height: 50px;
-}
-
 nav {
   display: flex;
   justify-content: center;
   gap: 1rem;
-  margin-top: 1rem;
+  background-color: #0056b3;
+  height: 50px;
+  align-items: center;
+  width: 100%;
 }
 
 nav a {
   text-decoration: none;
-  color: inherit;
+  color: white;
+}
+
+nav a:visited {
+  color: white;
 }


### PR DESCRIPTION
## Summary
- Style the navigation bar with a deeper blue background and white links
- Remove standalone blue bar element so navigation remains visible when switching pages

## Testing
- `python -m py_compile pelicanconf.py`

------
https://chatgpt.com/codex/tasks/task_e_68bd7519e78c8324a00bcd35e63e48c1