### PR TITLE
Add categories list to blog page

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -13,3 +13,13 @@ title: Blog
       {% endfor %}
     </ul>
 </div>
+
+<div class="container">
+    <h2>Categories</h2>
+    <ul class="category-list">
+      {% assign sorted_tags = site.tags | sort %}
+      {% for tag in sorted_tags %}
+        <li><a href="{{ '/tags/' | append: tag[0] | relative_url }}">{{ tag[0] }}</a> ({{ tag[1].size }})</li>
+      {% endfor %}
+    </ul>
+</div>

--- a/style.css
+++ b/style.css
@@ -133,3 +133,6 @@ a:hover {
   font-size: 0.9em;
   margin-left: 10px;
 }
+
+.category-list { list-style: none; padding-left: 0; margin-top: 20px; }
+.category-list li { display: inline-block; margin: 0 10px 10px 0; }


### PR DESCRIPTION
## Summary
- list blog categories and post counts with links on blog page
- style category list as inline tags

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll --no-document` *(fails: Net::HTTPClientException 403)*

------
https://chatgpt.com/codex/tasks/task_e_68be940fcdfc8324a8c6e99a40426b4d