### PR TITLE
Add categories list to blog page

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -2,14 +2,26 @@
 layout: default
 title: Blog
 ---
-<div class="container">
-    <h2>Posts</h2>
-    <ul class="post-list">
-      {% for post in site.posts %}
-        <li class="post-item">
-          <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
-          <span class="post-date">{{ post.date | date: "%B %-d, %Y" }}</span>
-        </li>
-      {% endfor %}
-    </ul>
+<div class="blog-grid">
+  <div class="container posts-container">
+      <h2>Posts</h2>
+      <ul class="post-list">
+        {% for post in site.posts %}
+          <li class="post-item">
+            <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
+            <span class="post-date">{{ post.date | date: "%B %-d, %Y" }}</span>
+          </li>
+        {% endfor %}
+      </ul>
+  </div>
+
+  <div class="container categories-container">
+      <h2>Categories</h2>
+      <ul class="category-list">
+        {% assign sorted_tags = site.tags | sort %}
+        {% for tag in sorted_tags %}
+          <li><a href="{{ '/tags/' | append: tag[0] | relative_url }}">{{ tag[0] }}</a> ({{ tag[1].size }})</li>
+        {% endfor %}
+      </ul>
+  </div>
 </div>

--- a/style.css
+++ b/style.css
@@ -133,3 +133,27 @@ a:hover {
   font-size: 0.9em;
   margin-left: 10px;
 }
+
+.blog-grid {
+  display: flex;
+  align-items: flex-start;
+  gap: 40px;
+}
+
+.posts-container {
+  flex: 3;
+}
+
+.categories-container {
+  flex: 1;
+}
+
+.category-list {
+  list-style: none;
+  padding-left: 0;
+  margin-top: 0;
+}
+
+.category-list li {
+  margin-bottom: 10px;
+}


### PR DESCRIPTION
## Summary
- list blog categories and post counts with links on blog page
- style category list as inline tags

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll --no-document` *(fails: Net::HTTPClientException 403)*

------
https://chatgpt.com/codex/tasks/task_e_68be940fcdfc8324a8c6e99a40426b4d