### PR TITLE
Add Jekyll build and Pages deployment workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bundle exec jekyll build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+gem "jekyll", "~> 4.3"
+# needed for Ruby 3.0+ when running `jekyll serve`
+gem "webrick", "~> 1.7"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build the site with Jekyll and deploy to GitHub Pages
- include Gemfile for bundler

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68bea34e724c83249814d03b0b7f8d11