### PR TITLE
style: refresh typography and layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,30 +1,34 @@
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600&family=Playfair+Display:wght@700&display=swap');
+
 body {
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 20px;
+  font-family: 'Open Sans', sans-serif;
+  margin: 0;
   line-height: 1.6;
-  background: #f8f9fa;
+  background: #fff;
   color: #333;
 }
 
 nav {
-  background: #2c3e50;
-  padding: 15px;
-  margin-bottom: 30px;
-  border-radius: 6px;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  background: #fff;
+  padding: 15px 0;
+  border-bottom: 1px solid #eee;
 }
 
 nav a {
-  margin-right: 20px;
   text-decoration: none;
-  color: white;
-  font-weight: 500;
+  color: #333;
+  font-weight: 600;
   transition: color 0.2s;
 }
 
 nav a:hover {
-  color: #3498db;
+  color: #0077cc;
 }
 
 nav .nav-icon {
@@ -33,7 +37,8 @@ nav .nav-icon {
   vertical-align: middle;
 }
 
-h1, h2 {
+h1, h2, h3 {
+  font-family: 'Playfair Display', serif;
   color: #2c3e50;
 }
 
@@ -48,10 +53,9 @@ a:hover {
 }
 
 .container {
-  background: white;
-  padding: 40px;
-  border-radius: 8px;
-  box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 40px 20px;
 }
 
 .intro {
@@ -89,13 +93,13 @@ a:hover {
 
 /* Headshot styles */
 .headshot {
-  width: 150px;
-  height: 150px;
+  width: 160px;
+  height: 160px;
   border-radius: 50%;
   float: right;
-  margin: 0 0 20px 20px; /* space from text */
+  margin: 0 0 20px 20px;
   object-fit: cover;
-  box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
 }
 
 /* Mobile: center the headshot and drop float */
@@ -103,7 +107,7 @@ a:hover {
   .headshot {
     float: none;
     display: block;
-    margin: 0 auto 20px auto;
+    margin: 0 auto 20px;
     width: 140px;
     height: 140px;
   }


### PR DESCRIPTION
## Summary
- import Google Fonts and apply Open Sans and Playfair Display
- restyle body, container, and headshot for cleaner layout
- make navigation sticky with flexbox spacing and link hover color tweak

## Testing
- `bundle exec jekyll build` *(fails: command not found: jekyll)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bea9451b3483249295c9669cd9139e