### PR TITLE
Add motto text within hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,12 +8,13 @@ title: Shibaprasad Bhattacharya
     <p class="hero-sub">
       Data Science | Analytics | AI | Strategy | Product Thinking
     </p>
+    <p class="hero-motto">
+      Asking the right questions to unlock insights.
+    </p>
   </div>
 </header>
 
 <div class="container">
-    <p><em>Asking the right questions to unlock insights.</em></p>
-
     <p>I am a Data Science Generalist who solves problems at the intersection of <strong>AI, Analytics, and Strategy</strong>. I enjoy tackling ambiguous, challenging problems with product-driven thinking.</p>
 
     <p>Currently working as <strong>Data Analyst II at Bristol Myers Squibb</strong>. Previously, I worked at <strong>Air India</strong> and <strong>Delhivery</strong>.</p>

--- a/style.css
+++ b/style.css
@@ -200,6 +200,14 @@ a:hover {
   margin: 0;
 }
 
+.hero-motto {
+  margin-top: 12px;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: #f9f9f9;   /* softer white for contrast */
+  opacity: 0.95;
+}
+
 /* If your nav is sticky, give the next section a bit more top space */
 .container:first-of-type { scroll-margin-top: 80px; }
 


### PR DESCRIPTION
## Summary
- Move motto inside hero block beneath tagline
- Style new hero-motto class for subtle presentation
- Remove duplicate motto from top content section
- Keep vertical bar separators in tagline

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c36cc313e08324830e2762c979fced