### PR TITLE
Use on-page tag anchors for blog categories

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -14,13 +14,31 @@ title: Blog
                 </li>
               {% endfor %}
             </ul>
+            {% if site.tags.size > 0 %}
+            <div class="tag-sections">
+              {% assign sorted_tags = site.tags | sort %}
+              {% for tag in sorted_tags %}
+              <section id="tag-{{ tag[0] | slugify }}" class="tag-section">
+                <h3>{{ tag[0] }}</h3>
+                <ul class="post-list">
+                  {% for tagged_post in tag[1] %}
+                  <li class="post-item">
+                    <a class="post-title" href="{{ tagged_post.url | relative_url }}">{{ tagged_post.title }}</a>
+                    <span class="post-date">{{ tagged_post.date | date: "%B %-d, %Y" }}</span>
+                  </li>
+                  {% endfor %}
+                </ul>
+              </section>
+              {% endfor %}
+            </div>
+            {% endif %}
         </div>
         <aside class="blog-categories">
             <h3>Categories</h3>
             <ul class="category-list">
               {% assign sorted_tags = site.tags | sort %}
               {% for tag in sorted_tags %}
-                <li><a href="{{ '/tags/' | append: tag[0] | relative_url }}">{{ tag[0] }}</a> ({{ tag[1].size }})</li>
+                <li><a href="#tag-{{ tag[0] | slugify }}">{{ tag[0] }}</a> ({{ tag[1].size }})</li>
               {% endfor %}
             </ul>
         </aside>


### PR DESCRIPTION
## Summary
- show per-tag post groupings directly on the blog page and anchor category links to those sections
- remove the need for separately generated tag pages by relying on in-page navigation

## Testing
- `bundle exec jekyll build` *(fails: jekyll executable missing because bundle install cannot reach rubygems.org)*
- `bundle install` *(fails: rubygems.org returns HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ca438340832489cb6218f0d84107