### PR TITLE
Add client-side filtering for blog categories

### DIFF
--- a/_includes/post-list.html
+++ b/_includes/post-list.html
@@ -1,0 +1,27 @@
+{% assign posts = include.posts %}
+{% assign list_classes = 'post-list' %}
+{% if include.list_class %}
+  {% assign list_classes = list_classes | append: ' ' | append: include.list_class %}
+{% endif %}
+{% if posts and posts != empty %}
+<ul class="{{ list_classes }}"{% if include.list_id %} id="{{ include.list_id }}"{% endif %}>
+  {% for post in posts %}
+    {% assign tag_slugs = '' %}
+    {% if post.tags %}
+      {% for tag in post.tags %}
+        {% assign tag_slug = tag | slugify %}
+        {% if tag_slugs != '' %}
+          {% assign tag_slugs = tag_slugs | append: ',' %}
+        {% endif %}
+        {% assign tag_slugs = tag_slugs | append: tag_slug %}
+      {% endfor %}
+    {% endif %}
+    <li class="post-item" data-tags="{{ tag_slugs }}">
+      <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
+      <span class="post-date">{{ post.date | date: "%B %-d, %Y" }}</span>
+    </li>
+  {% endfor %}
+</ul>
+{% else %}
+  <p class="no-posts">{{ include.empty_message | default: 'No posts found.' }}</p>
+{% endif %}

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -3,12 +3,6 @@ layout: default
 ---
 <div class="container">
   <h2>Posts tagged "{{ page.tag }}"</h2>
-  <ul class="post-list">
-    {% for post in site.tags[page.tag] %}
-      <li class="post-item">
-        <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
-        <span class="post-date">{{ post.date | date: "%B %-d, %Y" }}</span>
-      </li>
-    {% endfor %}
-  </ul>
+  {% assign tag_posts = site.tags[page.tag] %}
+  {% include post-list.html posts=tag_posts %}
 </div>

--- a/blog.html
+++ b/blog.html
@@ -5,24 +5,109 @@ title: Blog
 <div class="container">
     <div class="blog-wrapper">
         <div class="blog-posts">
-            <h2>Posts</h2>
-            <ul class="post-list">
-              {% for post in site.posts %}
-                <li class="post-item">
-                  <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
-                  <span class="post-date">{{ post.date | date: "%B %-d, %Y" }}</span>
-                </li>
-              {% endfor %}
-            </ul>
+            <h2 id="posts-heading">Posts</h2>
+            {% include post-list.html posts=site.posts list_id='blog-post-list' %}
+            <p class="no-posts" id="no-posts-message" hidden>No posts found for this category yet.</p>
         </div>
         <aside class="blog-categories">
             <h3>Categories</h3>
             <ul class="category-list">
+              <li><a href="{{ '/blog.html' | relative_url }}" data-tag-name="" data-tag-slug="">All posts</a></li>
               {% assign sorted_tags = site.tags | sort %}
               {% for tag in sorted_tags %}
-                <li><a href="{{ '/tags/' | append: tag[0] | relative_url }}">{{ tag[0] }}</a> ({{ tag[1].size }})</li>
+                {% assign tag_name = tag[0] %}
+                {% assign tag_slug = tag_name | slugify %}
+                <li>
+                  <a href="{{ '/blog.html?tag=' | append: tag_slug | relative_url }}"
+                     data-tag-name="{{ tag_name }}"
+                     data-tag-slug="{{ tag_slug }}">
+                    {{ tag_name }}
+                  </a>
+                  ({{ tag[1].size }})
+                </li>
               {% endfor %}
             </ul>
         </aside>
     </div>
 </div>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const postsList = document.getElementById('blog-post-list');
+    if (!postsList) {
+      return;
+    }
+
+    const heading = document.getElementById('posts-heading');
+    const noPostsMessage = document.getElementById('no-posts-message');
+    const postItems = Array.from(postsList.querySelectorAll('.post-item'));
+    const categoryLinks = Array.from(document.querySelectorAll('.category-list a'));
+
+    function setActiveLink(tagSlug) {
+      categoryLinks.forEach(function (link) {
+        const isActive = (link.dataset.tagSlug || '') === (tagSlug || '');
+        link.classList.toggle('active', isActive);
+      });
+    }
+
+    function updatePostsForTag(tagSlug, tagName, options) {
+      const config = options || {};
+      let visibleCount = 0;
+
+      postItems.forEach(function (item) {
+        const tags = item.dataset.tags ? item.dataset.tags.split(',') : [];
+        const shouldShow = !tagSlug || tags.includes(tagSlug);
+        item.hidden = !shouldShow;
+
+        if (shouldShow) {
+          visibleCount += 1;
+        }
+      });
+
+      if (tagSlug && !tagName) {
+        const matchingLink = categoryLinks.find(function (link) {
+          return (link.dataset.tagSlug || '') === tagSlug;
+        });
+        if (matchingLink) {
+          tagName = matchingLink.dataset.tagName;
+        }
+      }
+
+      if (tagSlug && tagName) {
+        heading.textContent = 'Posts tagged "' + tagName + '"';
+      } else {
+        heading.textContent = 'Posts';
+      }
+
+      if (noPostsMessage) {
+        noPostsMessage.hidden = visibleCount !== 0;
+      }
+
+      setActiveLink(tagSlug);
+
+      if (!config.skipHistoryUpdate) {
+        const url = new URL(window.location);
+        if (tagSlug) {
+          url.searchParams.set('tag', tagSlug);
+        } else {
+          url.searchParams.delete('tag');
+        }
+        window.history.replaceState({}, '', url);
+      }
+    }
+
+    categoryLinks.forEach(function (link) {
+      link.addEventListener('click', function (event) {
+        event.preventDefault();
+        updatePostsForTag(link.dataset.tagSlug || '', link.dataset.tagName || '');
+      });
+    });
+
+    const params = new URLSearchParams(window.location.search);
+    const initialTag = params.get('tag') || '';
+    if (initialTag) {
+      updatePostsForTag(initialTag, null, { skipHistoryUpdate: true });
+    } else {
+      updatePostsForTag('', '', { skipHistoryUpdate: true });
+    }
+  });
+</script>

--- a/style.css
+++ b/style.css
@@ -170,6 +170,17 @@ a:hover {
   margin: 0 0 10px 0;
 }
 
+.category-list a.active {
+  font-weight: 700;
+  color: #1d6fa5;
+}
+
+.no-posts {
+  color: #777;
+  font-style: italic;
+  margin-top: 10px;
+}
+
 /* Hero */
 .hero {
   background: linear-gradient(135deg, #26415a 0%, #1abc9c 100%);


### PR DESCRIPTION
## Summary
- add a reusable `post-list` include to share markup for post listings
- enhance the blog page to drive tag filtering with query-aware JavaScript
- style the active category link and reuse the include in the tag layout
- fix the tag layout include call by assigning the tag post collection first

## Testing
- bundle install *(fails: 403 Forbidden while fetching rubygems.org)*
- bundle exec jekyll build *(not run: missing bundled gems due to install failure)*

------
https://chatgpt.com/codex/tasks/task_e_68d581cae0b0832495d35039022197fd