### PR TITLE
Add Open Graph and Twitter meta tags to default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,6 +3,23 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% assign meta_title = page.title | default: site.title %}
+    {% assign meta_description = page.description | default: page.excerpt | default: site.description | default: site.title %}
+    {% assign meta_image = page.image | default: site.image | default: '/images/headshot.jpg' %}
+    {% assign meta_type = 'website' %}
+    {% if page.layout == 'post' %}
+      {% assign meta_type = 'article' %}
+    {% endif %}
+    <meta property="og:title" content="{{ meta_title }}">
+    <meta property="og:description" content="{{ meta_description | strip_html | strip_newlines }}">
+    <meta property="og:type" content="{{ meta_type }}">
+    <meta property="og:url" content="{{ page.url | absolute_url }}">
+    <meta property="og:site_name" content="{{ site.title }}">
+    <meta property="og:image" content="{{ meta_image | absolute_url }}">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="{{ meta_title }}">
+    <meta name="twitter:description" content="{{ meta_description | strip_html | strip_newlines }}">
+    <meta name="twitter:image" content="{{ meta_image | absolute_url }}">
     <title>{{ page.title }}</title>
     <link rel="stylesheet" href="{{ '/style.css' | relative_url }}">
     <link rel="icon" type="image/png" href="{{ '/images/headshot.jpg' | relative_url }}">


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter metadata to the default layout head section
- configure dynamic values for title, description, URL, type, and image fallbacks using page and site data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0b845274c83249cda81f0d953c6d1