### PR TITLE
Update About section to Sanofi and revise career progression

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ title: Shibaprasad Bhattacharya
     </p>
     <div class="hero-intro">
       <p>I build decision systems where the output is measured in dollars, time, or decisions changed, not in F1 scores. My work sits at the intersection of analytics, operations research, and product strategy. I've worked across logistics, aviation, and pharma R&D, always asking: what's the business problem we're actually solving? The math is a tool, not the goal.</p>
-      <p>Currently: Bristol Myers Squibb (Drug Development Analytics). Previously: Air India, Delhivery</p>
+      <p>Currently: Sanofi (Digital R&D). Previously: Bristol Myers Squibb, Air India, Delhivery.</p>
     </div>
   </div>
 </header>
@@ -28,7 +28,7 @@ title: Shibaprasad Bhattacharya
 
   <div class="section">
     <h3>Professional Journey</h3>
-    <p>My career has taken me through different industries: I started at Delhivery in Analytics &amp; BI, then moved to Air India's Operations Tech team, and now I'm with the Drug Development team at Bristol Myers Squibb, working on projects that hopefully help patients.</p>
+    <p>My career has taken me through different industries: I started at Delhivery in Analytics &amp; BI, then moved to Air India's Operations Tech team. Then I joined Bristol Myers Squibb in the Drug Development IT team, and now I am working with the Digital R&amp;D team at Sanofi, working on projects that hopefully help patients.</p>
   </div>
 
   <div class="section">


### PR DESCRIPTION
### Motivation
- Update the About section to reflect the current role at Sanofi (Digital R&D) and to correct the career progression narrative across prior employers.

### Description
- Modify `index.html` to change the hero line to "Currently: Sanofi (Digital R&D). Previously: Bristol Myers Squibb, Air India, Delhivery." and to rewrite the "Professional Journey" paragraph to show Delhivery → Air India → Bristol Myers Squibb (Drug Development IT) → Sanofi (Digital R&D).

### Testing
- No automated tests were run because this is a content-only edit to `index.html`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d47675b6cc8324824f0ff765ea52bd)