### PR TITLE
Replace subscribe form with Substack embed iframe

### DIFF
--- a/subscribe.html
+++ b/subscribe.html
@@ -16,17 +16,7 @@ layout: null
   <div class="container">
     <h1>Subscribe</h1>
     <p>Get new posts from <strong>Grain of Data</strong> in your inbox.</p>
-    <form action="https://magic.beehiiv.com/v1/514a261f-f4a0-46fc-96db-bf24d5002de8"
-          method="get" target="_blank"
-          style="display:flex; gap:8px; flex-wrap:wrap; margin-top:16px;">
-      <input type="email" name="email" placeholder="Enter your email"
-             required
-             style="flex:1; min-width:200px; padding:10px 14px; border:1px solid #ccc; border-radius:6px; font-size:1rem;" />
-      <button type="submit"
-              style="padding:10px 20px; background:#000; color:#fff; border:none; border-radius:6px; font-size:1rem; cursor:pointer;">
-        Subscribe
-      </button>
-    </form>
+    <iframe src="https://ordinaryanalysis.substack.com/embed" width="480" height="320" style="border: 1px solid #EEE; background: white" frameborder="0" scrolling="no"></iframe>
   </div>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Replace the existing Beehiiv email form with the provided Substack embed so the Subscribe page shows the Substack subscriber iframe.

### Description
- Replaced the form markup in `subscribe.html` with the exact Substack iframe: `<iframe src="https://ordinaryanalysis.substack.com/embed" width="480" height="320" style="border: 1px solid #EEE; background: white" frameborder="0" scrolling="no"></iframe>`.
- Preserved the surrounding page structure, copy, and includes so only the subscription component was swapped.

### Testing
- Ran `rg -n "substack|embed|subscriber|iframe" index.html subscribe.html _includes _layouts _posts` to locate relevant occurrences and verify the substitution succeeded.
- Printed `subscribe.html` via `sed -n '1,220p'` and `nl -ba subscribe.html` to confirm the iframe appears in the file as expected.
- Performed a diff check with `git diff -- subscribe.html` to confirm only the intended markup block changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4421f450832490c7f946d48cbd9e)