### PR TITLE
Replace Beehiiv subscription form with Substack embed for Ordinary Analysis

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,17 +13,7 @@ layout: default
   {% endif %}
   {{ content }}
   <hr />
-  <h3>Subscribe to Grain of Data</h3>
-  <form action="https://magic.beehiiv.com/v1/514a261f-f4a0-46fc-96db-bf24d5002de8"
-        method="get" target="_blank"
-        style="display:flex; gap:8px; flex-wrap:wrap; margin-top:16px;">
-    <input type="email" name="email" placeholder="Enter your email"
-           required
-           style="flex:1; min-width:200px; padding:10px 14px; border:1px solid #ccc; border-radius:6px; font-size:1rem;" />
-    <button type="submit"
-            style="padding:10px 20px; background:#000; color:#fff; border:none; border-radius:6px; font-size:1rem; cursor:pointer;">
-      Subscribe
-    </button>
-  </form>
+  <h3>Subscribe to Ordinary Analysis</h3>
+  <iframe src="https://ordinaryanalysis.substack.com/embed" width="480" height="320" style="border: 1px solid #EEE; background: white" frameborder="0" scrolling="no"></iframe>
   {% include giscus.html %}
 </div>

--- a/subscribe.html
+++ b/subscribe.html
@@ -15,18 +15,8 @@ layout: null
   {% include nav.html %}
   <div class="container">
     <h1>Subscribe</h1>
-    <p>Get new posts from <strong>Grain of Data</strong> in your inbox.</p>
-    <form action="https://magic.beehiiv.com/v1/514a261f-f4a0-46fc-96db-bf24d5002de8"
-          method="get" target="_blank"
-          style="display:flex; gap:8px; flex-wrap:wrap; margin-top:16px;">
-      <input type="email" name="email" placeholder="Enter your email"
-             required
-             style="flex:1; min-width:200px; padding:10px 14px; border:1px solid #ccc; border-radius:6px; font-size:1rem;" />
-      <button type="submit"
-              style="padding:10px 20px; background:#000; color:#fff; border:none; border-radius:6px; font-size:1rem; cursor:pointer;">
-        Subscribe
-      </button>
-    </form>
+    <p>Get new posts from <strong>Ordinary Analysis</strong> in your inbox.</p>
+    <iframe src="https://ordinaryanalysis.substack.com/embed" width="480" height="320" style="border: 1px solid #EEE; background: white" frameborder="0" scrolling="no"></iframe>
   </div>
 </body>
 </html>


### PR DESCRIPTION
### Motivation

- Replace the existing Grain of Data Beehiiv subscription widget with an embedded Substack subscription to promote Ordinary Analysis across post pages and the standalone subscribe page.

### Description

- Update `/_layouts/post.html` to remove the Beehiiv form, change the heading to "Subscribe to Ordinary Analysis", and add the Substack embed iframe.
- Update `/subscribe.html` to change the copy to reference "Ordinary Analysis" and replace the Beehiiv signup form with the Substack embed iframe.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4421f450832490c7f946d48cbd9e)