### PR TITLE
Update footer Substack link to Ordinary Analysis

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,7 +39,7 @@
       <p>
         <a href="https://www.linkedin.com/in/shibaprasad-bhattacharya/" target="_blank">LinkedIn</a> ·
         <a href="https://github.com/shibaprasadb" target="_blank">GitHub</a> ·
-        <a href="https://datasignal.substack.com" target="_blank">Substack</a>
+        <a href="https://ordinaryanalysis.substack.com/" target="_blank">Substack</a>
       </p>
     </footer>
     <script>


### PR DESCRIPTION
### Motivation
- Point the site footer Substack link to the author’s "Ordinary Analysis" newsletter instead of the previous Data Signal URL.

### Description
- Replaced the Substack URL in `_layouts/default.html` from `https://datasignal.substack.com` to `https://ordinaryanalysis.substack.com/`.

### Testing
- Ran `rg -n "Substack" _layouts/default.html` to verify the updated link and observed the new URL in the file.
- Inspected the change with `git diff -- _layouts/default.html`, which showed the single-line replacement and passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dddb0140088324ae45a3745eb6f3c9)