### PR TITLE
Fix blog filtering behavior and reduce post title size

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -54,20 +54,37 @@ title: Blog
     const postRows = Array.from(postsList.querySelectorAll('.post-row'));
     const filterLinks = Array.from(document.querySelectorAll('.filter-link'));
 
+    function normalizeTag(value) {
+      return (value || '').trim().toLowerCase();
+    }
+
+    function getRowTags(row) {
+      if (!row.dataset.tags) {
+        return [];
+      }
+
+      return row.dataset.tags
+        .split(',')
+        .map(function (tag) { return normalizeTag(tag); })
+        .filter(Boolean);
+    }
+
     function setActiveFilter(tagSlug) {
+      const normalizedTag = normalizeTag(tagSlug);
       filterLinks.forEach(function (link) {
-        const isActive = (link.dataset.tagSlug || '') === (tagSlug || '');
+        const isActive = normalizeTag(link.dataset.tagSlug || '') === normalizedTag;
         link.classList.toggle('active', isActive);
       });
     }
 
     function updatePostsForTag(tagSlug, options) {
       const config = options || {};
+      const normalizedTag = normalizeTag(tagSlug);
       let visibleCount = 0;
 
       postRows.forEach(function (row) {
-        const tags = row.dataset.tags ? row.dataset.tags.split(',') : [];
-        const shouldShow = !tagSlug || tags.includes(tagSlug);
+        const tags = getRowTags(row);
+        const shouldShow = !normalizedTag || tags.includes(normalizedTag);
         row.hidden = !shouldShow;
 
         if (shouldShow) {
@@ -79,12 +96,12 @@ title: Blog
         noPostsMessage.hidden = visibleCount !== 0;
       }
 
-      setActiveFilter(tagSlug);
+      setActiveFilter(normalizedTag);
 
       if (!config.skipHistoryUpdate) {
         const url = new URL(window.location.href);
-        if (tagSlug) {
-          url.searchParams.set('tag', tagSlug);
+        if (normalizedTag) {
+          url.searchParams.set('tag', normalizedTag);
         } else {
           url.searchParams.delete('tag');
         }
@@ -95,7 +112,8 @@ title: Blog
     filterLinks.forEach(function (link) {
       link.addEventListener('click', function (event) {
         event.preventDefault();
-        updatePostsForTag(link.dataset.tagSlug || '');
+        const linkTag = link.dataset.tagSlug || link.dataset.tagName || '';
+        updatePostsForTag(linkTag);
       });
     });
 

--- a/style.css
+++ b/style.css
@@ -392,7 +392,7 @@ nav .nav-icon:hover {
 }
 
 .post-row-title {
-  font-size: clamp(28px, 3.2vw, 42px);
+  font-size: clamp(24px, 2.4vw, 30px);
   margin: 0;
   line-height: 1.2;
 }
@@ -612,7 +612,7 @@ body.dark-mode .tag-reflections    { background: #581c87; color: #e9d5ff; }
   }
 
   .post-row-title {
-    font-size: clamp(24px, 8vw, 34px);
+    font-size: clamp(22px, 6.8vw, 28px);
   }
 }
 


### PR DESCRIPTION
### Motivation
- The blog tag filter was failing when tag casing or whitespace differed between filters and post tags, and filter clicks could reference `data-tag-name` instead of `data-tag-slug`. 
- Post titles in the list were visually oversized and needed smaller font sizes for desktop and mobile for better balance.

### Description
- Hardened filtering by adding `normalizeTag()` to trim and lowercase tag values and `getRowTags()` to normalize post row tags before comparison in `blog.html`.
- Updated active-filter highlighting and post visibility checks to use normalized tag values and changed history URL updates to write the normalized `tag` parameter in `blog.html`.
- Made filter click handling more robust by falling back to `data-tag-name` when `data-tag-slug` is not present in `blog.html`.
- Reduced the post title font sizes in `style.css` for desktop (`.post-row-title` from `clamp(28px, 3.2vw, 42px)` to `clamp(24px, 2.4vw, 30px)`) and for narrower breakpoints (`clamp(24px, 8vw, 34px)` to `clamp(22px, 6.8vw, 28px)`).

### Testing
- Ran `bundle exec jekyll build`, which failed in this environment because the `jekyll` executable is not installed. 
- Attempted a headless screenshot with `npx --yes playwright screenshot ...`, which failed due to npm registry access restrictions (HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0593de2208324bb2d7786334695c7)