### PR TITLE
Fix blog topic filtering links and slug normalization

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,7 +7,7 @@ layout: default
   {% if page.tags %}
   <p class="post-tags">
     {% for tag in page.tags %}
-      <a class="tag" href="/tags/{{ tag | slugify }}/">{{ tag }}</a>
+      <a class="tag" href="{{ '/blog.html' | relative_url }}?tag={{ tag | slugify | uri_escape }}">{{ tag }}</a>
     {% endfor %}
   </p>
   {% endif %}

--- a/blog.html
+++ b/blog.html
@@ -11,7 +11,7 @@ title: Blog
       {% assign tag_name = tag[0] %}
       {% assign tag_slug = tag_name | slugify %}
       <a class="filter-link"
-         href="{{ '/blog.html?tag=' | append: tag_slug | relative_url }}"
+         href="{{ '/blog.html' | relative_url }}?tag={{ tag_slug | uri_escape }}"
          data-tag-name="{{ tag_name }}"
          data-tag-slug="{{ tag_slug }}">
         {{ tag_name }}
@@ -55,7 +55,12 @@ title: Blog
     const filterLinks = Array.from(document.querySelectorAll('.filter-link'));
 
     function normalizeTag(value) {
-      return (value || '').trim().toLowerCase();
+      return (value || '')
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9\s-]/g, '')
+        .replace(/[\s_]+/g, '-')
+        .replace(/-+/g, '-');
     }
 
     function getRowTags(row) {


### PR DESCRIPTION
### Motivation
- Clicking topic tags on posts did not trigger the client-side blog filter because post tag links pointed at generated `/tags/...` pages while filtering logic lives on `blog.html` and expects a `?tag=` query parameter. 
- Tag value variations (spacing, punctuation, underscores) could fail matching because the client-side comparison used a simple lowercase check instead of slug normalization.

### Description
- Updated blog filter link generation to use an explicit query string format `{{ '/blog.html' | relative_url }}?tag={{ tag_slug | uri_escape }}` so tag links resolve consistently across base paths (`blog.html`).
- Changed post tag chips in `_layouts/post.html` to link to the blog filter page via `?tag=` (`{{ '/blog.html' | relative_url }}?tag={{ tag | slugify | uri_escape }}`) so clicking a tag applies the filter directly.
- Hardened the client-side `normalizeTag` function to perform slug-style normalization (lowercase, strip non-alphanumerics, convert spaces/underscores to hyphens, collapse multiple hyphens) so query values and stored tag slugs match reliably.

### Testing
- Attempted `bundle exec jekyll build` to validate the site build, but the command failed because the `jekyll` executable is not available in the environment (bundler error).
- Attempted `bundle install` to install dependencies and enable the build, but the install was blocked by upstream `rubygems.org` HTTP 403 responses, so dependency install and build verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f05b342214832486bd0af68748687d)