### PR TITLE
Fix blog post filtering to use tagSlug consistently

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -117,7 +117,7 @@ title: Blog
     filterLinks.forEach(function (link) {
       link.addEventListener('click', function (event) {
         event.preventDefault();
-        const linkTag = link.dataset.tagSlug || link.dataset.tagName || '';
+        const linkTag = link.dataset.tagSlug || '';
         updatePostsForTag(linkTag);
       });
     });

--- a/style.css
+++ b/style.css
@@ -379,6 +379,10 @@ nav .nav-icon:hover {
   border-bottom: 1px solid var(--color-border);
 }
 
+.post-row[hidden] {
+  display: none;
+}
+
 .post-row:first-child {
   border-top: 1px solid var(--color-border);
 }


### PR DESCRIPTION
## Summary
This PR fixes the blog post filtering functionality to use `tagSlug` as the primary identifier for filtering posts, and adds proper CSS styling to hide filtered posts.

## Key Changes
- **CSS**: Added `.post-row[hidden]` rule to properly hide posts with the `hidden` attribute using `display: none`
- **JavaScript**: Updated filter link click handler to use only `link.dataset.tagSlug` instead of falling back to `link.dataset.tagName`, ensuring consistent tag identification across the filtering system

## Implementation Details
The change removes the fallback to `tagName` in the filter link handler, which likely caused inconsistencies when tag slugs and tag names differed. By using only `tagSlug`, the filtering now has a single source of truth for tag identification. The accompanying CSS rule ensures that posts marked as hidden are properly removed from the visual layout.

https://claude.ai/code/session_01DNmuSrzxhdrjvD9jGUpTpw