### PR TITLE
Fix All filter and reduce post title size

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -6,7 +6,7 @@ title: Blog
   {% assign sorted_tags = site.tags | sort %}
   <div class="blog-filter-bar" aria-label="Post category filters">
     <span class="filter-label">Filter:</span>
-    <a class="filter-link" href="{{ '/blog.html' | relative_url }}" data-tag-name="All" data-tag-slug="">All</a>
+    <a class="filter-link" href="{{ '/blog.html' | relative_url }}" data-tag-name="All">All</a>
     {% for tag in sorted_tags %}
       {% assign tag_name = tag[0] %}
       {% assign tag_slug = tag_name | slugify %}
@@ -77,7 +77,9 @@ title: Blog
     function setActiveFilter(tagSlug) {
       const normalizedTag = normalizeTag(tagSlug);
       filterLinks.forEach(function (link) {
-        const isActive = normalizeTag(link.dataset.tagSlug || '') === normalizedTag;
+        const isActive = ('tagSlug' in link.dataset)
+          ? normalizeTag(link.dataset.tagSlug) === normalizedTag
+          : normalizedTag === '';
         link.classList.toggle('active', isActive);
       });
     }
@@ -117,7 +119,7 @@ title: Blog
     filterLinks.forEach(function (link) {
       link.addEventListener('click', function (event) {
         event.preventDefault();
-        const linkTag = link.dataset.tagSlug || '';
+        const linkTag = ('tagSlug' in link.dataset) ? link.dataset.tagSlug : '';
         updatePostsForTag(linkTag);
       });
     });

--- a/style.css
+++ b/style.css
@@ -396,9 +396,10 @@ nav .nav-icon:hover {
 }
 
 .post-row-title {
-  font-size: clamp(24px, 2.4vw, 30px);
+  font-size: 17px;
+  font-weight: 600;
   margin: 0;
-  line-height: 1.2;
+  line-height: 1.4;
 }
 
 .post-row-title a {
@@ -615,9 +616,6 @@ body.dark-mode .tag-reflections    { background: #581c87; color: #e9d5ff; }
     font-size: 16px;
   }
 
-  .post-row-title {
-    font-size: clamp(22px, 6.8vw, 28px);
-  }
 }
 
 /* Small mobile */


### PR DESCRIPTION
The All link had data-tag-slug="" (empty string), which is falsy in JS, causing fallthrough to the tag name "All" — a value no post has. Removed data-tag-slug from the All link and switched to explicit attribute-presence checks ('tagSlug' in link.dataset) so All unambiguously clears the filter.

Also reduced .post-row-title from clamp(24px–30px) to 17px/600 weight and removed the now-redundant mobile size override.