### PR TITLE
Update displayed contact email

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,5 +164,5 @@ This repository contains personal content and code. Feel free to reference the c
 ## Contact
 
 **Shibaprasad Bhattacharya**
-Email: shibaprasad@tuta.io
+Email: shibaprasad.b@outlook.com
 Website: https://shibaprasadb.github.io

--- a/index.html
+++ b/index.html
@@ -39,6 +39,6 @@ title: Shibaprasad Bhattacharya
   <p>Open to conversations about Product Analytics, Strategic Analytics, and Decision Sciences roles.</p>
 
   <div class="contact">
-    <p><strong>Contact:</strong> <a href="mailto:shibaprasad@tuta.io">shibaprasad@tuta.io</a></p>
+    <p><strong>Contact:</strong> <a href="mailto:shibaprasad.b@outlook.com">shibaprasad.b@outlook.com</a></p>
   </div>
 </div>


### PR DESCRIPTION
### Motivation
- Replace the outdated public contact email shown on the homepage and in the repository README with the current address.

### Description
- Updated the visible contact email and `mailto:` link in `index.html` and the contact email in `README.md` from `shibaprasad@tuta.io` to `shibaprasad.b@outlook.com`.

### Testing
- Ran `rg -n "shibaprasad@tuta\.io" README.md index.html || true`, `rg -n "shibaprasad\.b@outlook\.com" README.md index.html`, and `git status --short`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47f2fc336483248258832e2f9879d4)