### PR TITLE
Redesign homepage in an editorial, minimalist style

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,13 +25,18 @@
     <link rel="icon" type="image/svg+xml" href="{{ '/images/favicon.svg' | relative_url }}">
     <link rel="alternate" type="application/atom+xml" title="{{ site.title }} RSS Feed" href="{{ '/feed.xml' | absolute_url }}">
     <link rel="me" href="https://mstdn.party/@shibaprasad">
+    {% if page.url == '/' %}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,wght@0,400;0,500;0,600;1,400;1,500&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+    {% endif %}
     <!-- GoatCounter Analytics -->
     <script data-goatcounter="https://shibaprasadb.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>
     <!-- Umami Analytics -->
     <script defer src="https://cloud.umami.is/script.js" data-website-id="2e67cd5c-f499-4fba-a139-481c5adb30c4"></script>
 </head>
-<body>
+<body{% if page.url == '/' %} class="home"{% endif %}>
     {% include nav.html %}
     {{ content }}
     <footer class="site-footer">

--- a/index.html
+++ b/index.html
@@ -1,44 +1,70 @@
 ---
 layout: default
 title: Shibaprasad Bhattacharya
+description: "Product & strategic analytics. Decision intelligence."
 ---
-<header class="hero">
-  <div class="hero-inner">
-    <img src="images/headshot.jpg" alt="Shibaprasad Bhattacharya" class="hero-photo">
-    <h1>Shibaprasad Bhattacharya</h1>
-    <p class="hero-sub">
-      Product & Strategic Analytics | Decision Intelligence
-    </p>
-    <p class="hero-motto">
-      Building decision systems that move the bottom line.
-    </p>
-    <div class="hero-intro">
-      <p>I build decision systems where the output is measured in dollars, time, or decisions changed, not in F1 scores. My work sits at the intersection of analytics, operations research, and product strategy. I've worked across logistics, aviation, and pharma R&D, always asking: what's the business problem we're actually solving? The math is a tool, not the goal.</p>
-      <p>Currently: Sanofi (Digital R&D). Previously: Bristol Myers Squibb, Air India, Delhivery.</p>
+<div class="home-wrap">
+
+  <section id="intro">
+    <p>I build decision systems — the kind measured in dollars, hours, or decisions changed, not F1 scores. My work sits where analytics, operations research, and product strategy meet, across logistics, aviation, and pharma R&amp;D. The math is a tool; framing the problem right is the actual job.</p>
+    <p>I do my best work on messy, ambiguous problems — the ones where the hard part is figuring out what question to ask.</p>
+  </section>
+
+  <hr class="rule">
+
+  <section id="now">
+    <span class="label">Now</span>
+    <p class="now-line"><span class="dot" aria-hidden="true"></span> Senior Analytics Specialist at Sanofi, Hyderabad — building a forecasting proof-of-concept for clinical trial supply chains.</p>
+  </section>
+
+  <hr class="rule">
+
+  <section id="writing">
+    <span class="label">Recent writing</span>
+    {% for post in site.posts limit:3 %}
+    <div class="entry">
+      <span class="title"><a href="{{ post.url | relative_url }}">{{ post.title }}</a></span>
+      <span class="fill"></span>
+      <span class="meta mono">{{ post.date | date: "%b %Y" }}</span>
     </div>
-  </div>
-</header>
+    {% endfor %}
+  </section>
 
-<div class="container about">
-  <div class="section">
-    <p>I do my best work on messy, ambiguous business problems - the kind where you're not sure what question to ask, let alone how to answer it. Framing the problem right is usually harder (and more important) than building the perfect model.</p>
+  <hr class="rule">
 
-    <p>I believe analytics creates real value when it's tied to strategy and product decisions. I'm particularly interested in how data shapes product strategy - from feature prioritization to market expansion to user behavior analysis. That's where I like to work - where data actually drives what happens next.</p>
-  </div>
+  <section id="journey">
+    <span class="label">Professional journey</span>
+    <div class="entry">
+      <span class="idx mono">01</span>
+      <span class="title">Delhivery — Analytics &amp; BI</span>
+      <span class="fill"></span>
+      <span class="meta mono"></span>
+    </div>
+    <div class="entry">
+      <span class="idx mono">02</span>
+      <span class="title">Air India — Operations Tech</span>
+      <span class="fill"></span>
+      <span class="meta mono"></span>
+    </div>
+    <div class="entry">
+      <span class="idx mono">03</span>
+      <span class="title">Bristol Myers Squibb — Drug Development IT</span>
+      <span class="fill"></span>
+      <span class="meta mono"></span>
+    </div>
+    <div class="entry">
+      <span class="idx mono">04</span>
+      <span class="title">Sanofi — Senior Analytics Specialist</span>
+      <span class="fill"></span>
+      <span class="meta mono">2026 →</span>
+    </div>
+  </section>
 
-  <div class="section">
-    <h3>Professional Journey</h3>
-    <p>My career has taken me through different industries: I started at Delhivery in Analytics &amp; BI, then moved to Air India's Operations Tech team. Then I joined Bristol Myers Squibb in the Drug Development IT team, and now I am working with the Digital R&amp;D team at Sanofi, working on projects that hopefully help patients.</p>
-  </div>
+  <hr class="rule">
 
-  <div class="section">
-    <h3>Outside of Work</h3>
-    <p>When I'm not working with data, you can find me strength training, exploring the art of brewing coffee, and occasionally writing <a href="https://ordinaryanalysis.substack.com/">Ordinary Analysis</a> - my blog where I share both technical explorations and personal reflections.</p>
-  </div>
+  <section id="outside">
+    <span class="label">Outside of work</span>
+    <p>Training for half marathons, playing pickleball, learning guitar, and writing <a href="https://ordinaryanalysis.substack.com/">Ordinary Analysis</a> — a newsletter on cities, politics, and the patterns hiding in ordinary things.</p>
+  </section>
 
-  <p>Open to conversations about Product Analytics, Strategic Analytics, and Decision Sciences roles.</p>
-
-  <div class="contact">
-    <p><strong>Contact:</strong> <a href="mailto:shibaprasad.b@outlook.com">shibaprasad.b@outlook.com</a></p>
-  </div>
 </div>

--- a/style.css
+++ b/style.css
@@ -635,6 +635,235 @@ body.dark-mode .tag-reflections    { background: #581c87; color: #e9d5ff; }
 }
 
 /* ============================================
+   Homepage Editorial Redesign
+   Scoped to body.home (index page only) so
+   blog.html / publications.html / subscribe.html
+   are unaffected.
+   ============================================ */
+:root {
+  --paper: #EEF0EC;
+  --ink: #1C1E1B;
+  --ink-soft: #63665F;
+  --rule: #D2D5CD;
+  --accent: #1D3557;
+  --accent-soft: #E2E6E9;
+}
+
+body.dark-mode {
+  --paper: #14161A;
+  --ink: #E6E8E3;
+  --ink-soft: #93968E;
+  --rule: #2C2F2B;
+  --accent: #7FAE8F;
+  --accent-soft: #1B241E;
+}
+
+body.home {
+  background: var(--paper);
+  color: var(--ink);
+}
+
+body.home nav {
+  background: var(--paper);
+  border-bottom-color: var(--rule);
+}
+
+body.home .nav-brand,
+body.home .nav-links a {
+  color: var(--ink);
+}
+
+body.home .nav-links a:hover,
+body.home .nav-links a.active,
+body.home .nav-links a:visited:hover {
+  color: var(--accent);
+}
+
+body.home #dark-toggle {
+  color: var(--ink);
+}
+
+body.home #dark-toggle:hover {
+  color: var(--accent);
+}
+
+body.home .site-footer {
+  background: var(--paper);
+  border-top-color: var(--rule);
+}
+
+body.home .site-footer a {
+  color: var(--ink-soft);
+}
+
+body.home .site-footer a:hover {
+  color: var(--accent);
+}
+
+body.home a:focus-visible,
+body.home button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+.home-wrap {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 56px 24px 64px;
+  font-family: 'Newsreader', Georgia, serif;
+  font-size: 18px;
+  line-height: 1.65;
+  color: var(--ink);
+}
+
+.home-wrap .mono {
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  letter-spacing: .03em;
+}
+
+.home-wrap a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--rule);
+}
+
+.home-wrap a:hover {
+  border-bottom-color: var(--accent);
+  text-decoration: none;
+}
+
+.home-wrap .rule {
+  border: none;
+  border-top: 1px dotted var(--rule);
+  margin: 36px 0;
+}
+
+.home-wrap section {
+  margin-bottom: 8px;
+}
+
+.home-wrap .label {
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  letter-spacing: .03em;
+  font-size: .72rem;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  margin: 0 0 18px;
+  display: block;
+}
+
+.home-wrap p {
+  margin: 0 0 16px;
+}
+
+.home-wrap p:last-child {
+  margin-bottom: 0;
+}
+
+.home-wrap .now-line {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  font-size: 1.02rem;
+  margin: 0;
+}
+
+.home-wrap .dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex-shrink: 0;
+  position: relative;
+  top: -2px;
+}
+
+.home-wrap .entry {
+  display: flex;
+  align-items: baseline;
+  margin-bottom: 14px;
+}
+
+.home-wrap .entry:last-child {
+  margin-bottom: 0;
+}
+
+.home-wrap .entry .idx {
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  letter-spacing: .03em;
+  color: var(--ink-soft);
+  font-size: .72rem;
+  margin-right: 10px;
+  flex-shrink: 0;
+}
+
+.home-wrap .entry .title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.home-wrap .entry .title a {
+  border-bottom: 1px solid var(--rule);
+}
+
+.home-wrap .entry .title a:hover {
+  border-bottom-color: var(--accent);
+}
+
+.home-wrap .entry .fill {
+  flex: 1;
+  border-bottom: 1px dotted var(--rule);
+  margin: 0 8px;
+  height: 0;
+  transform: translateY(-5px);
+  min-width: 20px;
+}
+
+.home-wrap .entry .meta {
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  letter-spacing: .03em;
+  white-space: nowrap;
+  font-size: .76rem;
+  color: var(--ink-soft);
+  flex-shrink: 0;
+}
+
+@media (max-width: 480px) {
+  .home-wrap {
+    padding: 40px 20px 48px;
+  }
+
+  .home-wrap .entry .title {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+  }
+
+  .home-wrap .entry .fill {
+    display: none;
+  }
+
+  .home-wrap .entry {
+    flex-wrap: wrap;
+    column-gap: 8px;
+  }
+
+  .home-wrap .entry .meta {
+    margin-left: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-wrap,
+  .home-wrap * {
+    transition: none !important;
+    animation: none !important;
+  }
+}
+
+/* ============================================
    Utility for scroll-margin with sticky nav
    ============================================ */
 .container:first-of-type {


### PR DESCRIPTION
Replace the hero/about layout with a serif+mono, dot-leader editorial layout (Newsreader/IBM Plex Mono) scoped to the homepage only via body.home, reusing the site's existing dark-mode toggle and single-stylesheet setup. Recent writing now pulls the 3 latest posts straight from site.posts instead of being hardcoded.