### PR TITLE
Reverse professional journey order and update job titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,27 +36,27 @@ description: "Product & strategic analytics. Decision intelligence."
     <span class="label">Professional journey</span>
     <div class="entry">
       <span class="idx mono">01</span>
-      <span class="title">Delhivery — Analytics &amp; BI</span>
+      <span class="title">Sanofi — Senior Analytics Specialist (Digital R&amp;D)</span>
       <span class="fill"></span>
-      <span class="meta mono"></span>
+      <span class="meta mono">2026 →</span>
     </div>
     <div class="entry">
       <span class="idx mono">02</span>
-      <span class="title">Air India — Operations Tech</span>
+      <span class="title">Bristol Myers Squibb — Lead Data Analyst (Drug Development IT)</span>
       <span class="fill"></span>
       <span class="meta mono"></span>
     </div>
     <div class="entry">
       <span class="idx mono">03</span>
-      <span class="title">Bristol Myers Squibb — Drug Development IT</span>
+      <span class="title">Air India — Associate Manager (Operations Tech)</span>
       <span class="fill"></span>
       <span class="meta mono"></span>
     </div>
     <div class="entry">
       <span class="idx mono">04</span>
-      <span class="title">Sanofi — Senior Analytics Specialist</span>
+      <span class="title">Delhivery — Senior Analyst (Analytics &amp; BI)</span>
       <span class="fill"></span>
-      <span class="meta mono">2026 →</span>
+      <span class="meta mono"></span>
     </div>
   </section>
 


### PR DESCRIPTION
### Motivation
- Present the professional journey in reverse-chronological order and include company plus designation/functional area for each entry.

### Description
- Reordered the `index.html` professional journey section so Sanofi appears first and Delhivery last.
- Updated each `<span class="title">` to the requested designations: `Sanofi — Senior Analytics Specialist (Digital R&D)`, `Bristol Myers Squibb — Lead Data Analyst (Drug Development IT)`, `Air India — Associate Manager (Operations Tech)`, and `Delhivery — Senior Analyst (Analytics & BI)`.
- Moved the `2026 →` meta timestamp to the Sanofi entry to indicate the current role.
- Changes were committed (commit `d518360`).

### Testing
- Ran `bundle exec jekyll build`, which failed because the `jekyll` executable is missing and Bundler suggests running `bundle install`.
- No other automated tests were present or executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f957279c48324add739e6043b8951)