### PR TITLE
Fix markdown tables and ordered-list numbering not rendering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,9 @@ excerpt_separator: <!--more-->
 feed:
   path: feed.xml
 
+kramdown:
+  input: GFM
+
 defaults:
   - scope:
       path: ""

--- a/_posts/2026-07-09-cursorbench-analysis.md
+++ b/_posts/2026-07-09-cursorbench-analysis.md
@@ -57,15 +57,15 @@ Now the story time, what this means?
 
 1. **Cost does buy score, but the returns are sharply diminishing.**
 
-All the models that we used, roughly agrees with this. Log(cost) beats raw cost if Composer is removed. And the slope of the mixed model also confirms it - doubling cost buys roughly 6.7 points [^1], consistently, once you control for which family you're in.
+   All the models that we used, roughly agrees with this. Log(cost) beats raw cost if Composer is removed. And the slope of the mixed model also confirms it - doubling cost buys roughly 6.7 points [^1], consistently, once you control for which family you're in.
 
 2. **Curios case of Composer**
 
-Composer is developed by Cursor, and it broke the log(cost) structure completely. For the statistical analysis, we filtered it out as an outlier. But the more honest reading might be (if the numbers to be believed) : it is a well optimised cheap model.
+   Composer is developed by Cursor, and it broke the log(cost) structure completely. For the statistical analysis, we filtered it out as an outlier. But the more honest reading might be (if the numbers to be believed) : it is a well optimised cheap model.
 
 3. **Family matters**
 
-The mixed model splits the leftover variance (whatever cost doesn't explain) into two parts: how much comes from which family versus everything else. Squaring the standard deviations and comparing them, family accounts for ~85% of that leftover variation, noise only ~15%. In plain terms: pick two model variants at the same price, and which family they belong to explains most of the score gap between them.
+   The mixed model splits the leftover variance (whatever cost doesn't explain) into two parts: how much comes from which family versus everything else. Squaring the standard deviations and comparing them, family accounts for ~85% of that leftover variation, noise only ~15%. In plain terms: pick two model variants at the same price, and which family they belong to explains most of the score gap between them.
 
 ---
 


### PR DESCRIPTION
Jekyll was using kramdown's native input dialect, which doesn't reliably parse GFM pipe tables and silently ignores them; switching to input: GFM (kramdown-parser-gfm, already bundled with Jekyll) fixes that. Separately, the cursorbench post's numbered list had each item's explanatory paragraph left-aligned instead of indented under the list item, which breaks list continuity in both kramdown and CommonMark — kramdown was splitting it into three single-item lists and, unlike GitHub's renderer, not preserving each one's start number, so every item showed "1." Indenting the paragraphs keeps it one list.