### PR TITLE
Add styles for markdown tables

### DIFF
--- a/style.css
+++ b/style.css
@@ -480,6 +480,49 @@ button:focus-visible {
   line-height: 1.5;
 }
 
+
+/* ============================================
+   Tables
+   ============================================ */
+table {
+  width: 100%;
+  margin: 28px 0;
+  border-collapse: collapse;
+  font-size: 0.95em;
+  line-height: 1.45;
+}
+
+th,
+td {
+  padding: 10px 14px;
+  border: 1px solid var(--color-border);
+  vertical-align: top;
+}
+
+th {
+  font-weight: 600;
+  text-align: left;
+  background: var(--color-accent-soft);
+}
+
+tbody tr:nth-child(even) {
+  background: color-mix(in srgb, var(--color-accent-soft) 35%, transparent);
+}
+
+@supports not (background: color-mix(in srgb, white, black)) {
+  tbody tr:nth-child(even) {
+    background: var(--color-accent-soft);
+  }
+}
+
+@media (max-width: 768px) {
+  table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+}
+
 /* ============================================
    Images
    ============================================ */


### PR DESCRIPTION
### Motivation
- Markdown tables were not rendering with site styling and could break layout on narrow viewports, so site-wide CSS was needed to make tables readable and consistent with the theme.

### Description
- Added a `Tables` section to `style.css` that sets full-width layout, `border-collapse`, sensible `font-size`/`line-height`, and spacing for tables.
- Styled `th`/`td` with padding and borders and added header background using `var(--color-accent-soft)` for visual consistency.
- Implemented alternating row shading via `color-mix()` with an `@supports` fallback and added a responsive rule that enables horizontal scrolling for wide tables on small screens.
- Changes were saved and committed to the repository in `style.css`.

### Testing
- Ran `git diff --check`, which returned no issues and the change was staged for commit.
- Attempted `bundle exec jekyll build`, but the Jekyll executable was not available in the current bundle so the site build could not be run.
- Attempted `bundle install`, which failed to fetch gems because `rubygems.org` returned `403 Forbidden`, preventing dependency installation and a local site build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50a713204c83249a02275ee5ea9e0b)