### PR TITLE
Rename navbar label from Blog to ESSAYS

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -7,7 +7,7 @@
     <button id="dark-toggle" aria-label="Toggle dark mode">◐</button>
   </div>
   <nav>
-    <a href="{{ '/blog.html' | relative_url }}">Blog</a>
+    <a href="{{ '/blog.html' | relative_url }}">ESSAYS</a>
     <a href="{{ '/publications.html' | relative_url }}">Publications</a>
     <a href="{{ '/subscribe.html' | relative_url }}">Subscribe</a>
     <a href="{{ '/feed.xml' | relative_url }}">RSS</a>


### PR DESCRIPTION
### Motivation
- Update the site navigation label to use the preferred word "ESSAYS" while keeping the existing `/blog.html` link and feed behavior unchanged.

### Description
- Changed the navbar display text in `_includes/nav.html` from `Blog` to `ESSAYS` without modifying any links or other nav items.

### Testing
- Ran `git diff --check` which passed. 
- Attempted `bundle exec jekyll build` but it could not run due to missing local gems (`bundler: command not found: jekyll`); running `bundle install` is required to execute the build locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51f8f57c3483249a81f853aaf7e1d9)