### PR TITLE
Use default layout for subscribe page

### DIFF
--- a/subscribe.html
+++ b/subscribe.html
@@ -1,22 +1,9 @@
 ---
 title: Subscribe
-layout: null
+layout: default
 ---
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <title>Subscribe — {{ site.title }}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="stylesheet" href="/style.css" />
-  <link rel="icon" type="image/svg+xml" href="/images/favicon.svg" />
-</head>
-<body>
-  {% include nav.html %}
-  <div class="container">
-    <h1>Subscribe</h1>
-    <p>Get new posts from <strong>Ordinary Analysis</strong> in your inbox.</p>
-    <iframe src="https://ordinaryanalysis.substack.com/embed" width="480" height="320" style="border: 1px solid #EEE; background: white" frameborder="0" scrolling="no"></iframe>
-  </div>
-</body>
-</html>
+<div class="container">
+  <h1>Subscribe</h1>
+  <p>Get new posts from <strong>Ordinary Analysis</strong> in your inbox.</p>
+  <iframe src="https://ordinaryanalysis.substack.com/embed" width="480" height="320" style="border: 1px solid #EEE; background: white" frameborder="0" scrolling="no"></iframe>
+</div>


### PR DESCRIPTION
### Motivation
- Make the `subscribe` page inherit the site-wide metadata, navigation, footer, analytics, fonts, RSS link, and dark-mode script from the shared layout instead of duplicating them.
- Remove duplicated document shell markup to simplify maintenance and ensure consistent site behavior.

### Description
- Change the page front matter from `layout: null` to `layout: default` in `subscribe.html`.
- Remove the duplicated `<!doctype html>`, `<html>`, `<head>`, `<body>`, stylesheet and favicon links, and the `{% include nav.html %}` wrapper so only the inner content container remains.

### Testing
- Ran `git diff --check` to verify there are no whitespace or diff errors and it completed successfully.
- Verified the working tree status with `git status --short` to confirm only the intended file changed.
- Inspected `subscribe.html` contents to ensure the front matter and inner container are correct after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a632118570c8324acce3edd7b7ec677)