### PR TITLE
Add previous and next post navigation

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,6 +12,24 @@ layout: default
   </p>
   {% endif %}
   {{ content }}
+  {% if page.previous or page.next %}
+  <nav class="post-nav" aria-label="Essay navigation">
+    {% if page.previous %}
+    <div class="entry">
+      <span class="meta mono">Previous essay</span>
+      <span class="fill" aria-hidden="true"></span>
+      <span class="title"><a href="{{ page.previous.url | relative_url }}">{{ page.previous.title }}</a></span>
+    </div>
+    {% endif %}
+    {% if page.next %}
+    <div class="entry">
+      <span class="meta mono">Next essay</span>
+      <span class="fill" aria-hidden="true"></span>
+      <span class="title"><a href="{{ page.next.url | relative_url }}">{{ page.next.title }}</a></span>
+    </div>
+    {% endif %}
+  </nav>
+  {% endif %}
   <hr />
   <h3>Subscribe to Ordinary Analysis</h3>
   <iframe src="https://ordinaryanalysis.substack.com/embed" width="480" height="320" style="border: 1px solid #EEE; background: white" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
### Motivation
- Improve crawl paths and help readers continue exploring by adding explicit previous/next essay links to post pages. 
- Keep the site’s visual language consistent by reusing the existing `.entry`, `.fill`, `.meta`, and `.mono` styles.

### Description
- Insert a conditional navigation block immediately after `{{ content }}` and before the subscription block that renders when `page.previous` or `page.next` exist. 
- Use Jekyll’s `page.previous` and `page.next` to populate link targets and titles. 
- Reuse the existing `.entry`, `.fill`, `.meta`, and `.mono` classes for layout and styling and add `aria-label="Essay navigation"` to the container for accessibility. 
- Link URLs are rendered with `| relative_url` so paths remain correct for the site base.

### Testing
- Attempted `bundle exec jekyll build` but it could not run because the `jekyll` executable is not installed in the environment. 
- Attempted `bundle install && bundle exec jekyll build` but dependency installation failed because RubyGems returned HTTP 403 while fetching gems, so a full site build could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6325196af083249ecc4d1ae3adb616)