### PR TITLE
Remove GoatCounter and document Umami-only analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ Blog posts include Giscus-powered comments. Configure in `_includes/giscus.html`
 
 ### Newsletter Integration
 
-Substack newsletter (Data Signal) signup forms are embedded on post pages and the dedicated subscribe page (`subscribe.html`).
+Substack newsletter (Ordinary Analysis) signup forms are embedded on post pages and the dedicated subscribe page (`subscribe.html`).
 
 ### Analytics
 
-Umami is integrated as the single analytics platform. Using one analytics script keeps the page lighter while still providing privacy-friendly traffic and content metrics.
+Umami is integrated as the single analytics platform.
 
 Configuration is in `_layouts/default.html`.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A minimal, responsive personal website featuring technical writing on analytics,
 - **Deployment:** GitHub Pages via GitHub Actions
 - **Comments:** Giscus (GitHub Discussions)
 - **Analytics:** Umami
-- **Newsletter:** Beehiiv integration
+- **Newsletter:** Substack integration
 - **RSS/Atom Feed:** Jekyll Feed plugin (`/feed.xml`)
 
 ## Local Development

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A minimal, responsive personal website featuring technical writing on analytics,
 - **Static Site Generator:** Jekyll 4.3
 - **Deployment:** GitHub Pages via GitHub Actions
 - **Comments:** Giscus (GitHub Discussions)
-- **Analytics:** GoatCounter, Umami
+- **Analytics:** Umami
 - **Newsletter:** Beehiiv integration
 - **RSS/Atom Feed:** Jekyll Feed plugin (`/feed.xml`)
 
@@ -113,9 +113,7 @@ Substack newsletter (Data Signal) signup forms are embedded on post pages and th
 
 ### Analytics
 
-Two analytics platforms are integrated:
-- GoatCounter for privacy-focused metrics
-- Umami for detailed analytics
+Umami is integrated as the single analytics platform. Using one analytics script keeps the page lighter while still providing privacy-friendly traffic and content metrics.
 
 Configuration is in `_layouts/default.html`.
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -81,9 +81,6 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,wght@0,400;0,500;0,600;1,400;1,500&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
-    <!-- GoatCounter Analytics -->
-    <script data-goatcounter="https://shibaprasadb.goatcounter.com/count"
-            async src="//gc.zgo.at/count.js"></script>
     <!-- Umami Analytics -->
     <script defer src="https://cloud.umami.is/script.js" data-website-id="2e67cd5c-f499-4fba-a139-481c5adb30c4"></script>
 </head>


### PR DESCRIPTION
### Motivation
- Reduce duplicate analytics and simplify the site by using a single privacy-friendly provider (Umami) to keep pages lighter and the tracking configuration straightforward.

### Description
- Removed the GoatCounter script from `_layouts/default.html` and updated `README.md` to state that Umami is the single analytics platform and to document the performance rationale.

### Testing
- Ran `git diff --check` successfully; attempts to run `bundle install` / `bundle exec jekyll build`, `npx --yes lighthouse ...`, and the PageSpeed Insights `curl` request failed due to network / Rubygems / npm 403 errors, so the site build and Lighthouse/PSI performance checks could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63265dab048324be1d0b459a22d148)